### PR TITLE
Add trends dashboard for visualizing metrics across runs

### DIFF
--- a/src/pitlane/cli.py
+++ b/src/pitlane/cli.py
@@ -167,6 +167,25 @@ def report(
         webbrowser.open(report_path.resolve().as_uri())
 
 
+@app.command()
+def trends(
+    runs_dir: str = typer.Option("runs", help="Directory containing run results"),
+    port: int = typer.Option(8095, help="Port for the dashboard server"),
+    no_open: bool = typer.Option(
+        False, "--no-open", help="Do not open browser automatically"
+    ),
+):
+    """Start the trends dashboard to visualize metrics across runs."""
+    from pitlane.dashboard.server import start_server
+
+    runs_path = Path(runs_dir)
+    if not runs_path.exists():
+        typer.echo(f"Error: runs directory not found: {runs_dir}", err=True)
+        raise typer.Exit(1)
+
+    start_server(runs_path, port=port, open_browser=not no_open)
+
+
 def _examples_source() -> Path | None:
     # Installed package: examples are bundled next to cli.py
     pkg = Path(__file__).parent / "examples"

--- a/src/pitlane/dashboard/scanner.py
+++ b/src/pitlane/dashboard/scanner.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+from junitparser import JUnitXml
+
+
+@dataclass
+class SuiteSummary:
+    """Metrics for a single assistant/task pair within a run."""
+
+    assistant: str
+    task: str
+    weighted_score: float | None
+    assertion_pass_rate: float | None
+    cost_usd: float | None
+    wall_clock_seconds: float | None
+    token_usage_input: float | None
+    token_usage_output: float | None
+    token_usage_input_cached: float | None
+    tool_calls_count: float | None
+    files_created: float | None
+    files_modified: float | None
+    timed_out: float | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class RunSummary:
+    """Summary of a single evaluation run."""
+
+    run_id: str
+    timestamp: str
+    assistants: list[str]
+    tasks: list[str]
+    repeat: int
+    suites: list[SuiteSummary]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "timestamp": self.timestamp,
+            "assistants": self.assistants,
+            "tasks": self.tasks,
+            "repeat": self.repeat,
+            "suites": [s.to_dict() for s in self.suites],
+        }
+
+
+def _parse_float(value: str | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (ValueError, TypeError):
+        return None
+
+
+def _parse_timestamp(meta: dict) -> datetime | None:
+    """Extract a timezone-aware datetime from meta.yaml data."""
+    ts = meta.get("timestamp")
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(str(ts))
+    except (ValueError, TypeError):
+        return None
+
+
+def _parse_date_bound(date_str: str) -> datetime:
+    """Parse a YYYY-MM-DD string into a timezone-aware datetime."""
+    dt = datetime.strptime(date_str, "%Y-%m-%d")
+    return dt.replace(tzinfo=timezone.utc)
+
+
+def _extract_suites(junit_path: Path) -> list[SuiteSummary]:
+    """Parse junit.xml and extract suite-level metrics."""
+    xml = JUnitXml.fromfile(str(junit_path))
+    suites: list[SuiteSummary] = []
+
+    for suite in xml:
+        parts = suite.name.split(" / ", 1)
+        if len(parts) != 2:
+            continue
+        assistant, task = parts
+
+        props = {p.name: p.value for p in suite.properties()}
+
+        suites.append(
+            SuiteSummary(
+                assistant=assistant,
+                task=task,
+                weighted_score=_parse_float(props.get("weighted_score")),
+                assertion_pass_rate=_parse_float(props.get("assertion_pass_rate")),
+                cost_usd=_parse_float(props.get("cost_usd")),
+                wall_clock_seconds=suite.time if suite.time else None,
+                token_usage_input=_parse_float(props.get("token_usage_input")),
+                token_usage_output=_parse_float(props.get("token_usage_output")),
+                token_usage_input_cached=_parse_float(
+                    props.get("token_usage_input_cached")
+                ),
+                tool_calls_count=_parse_float(props.get("tool_calls_count")),
+                files_created=_parse_float(props.get("files_created")),
+                files_modified=_parse_float(props.get("files_modified")),
+                timed_out=_parse_float(props.get("timed_out")),
+            )
+        )
+
+    return suites
+
+
+def scan_runs(
+    runs_dir: Path,
+    date_from: str | None = None,
+    date_to: str | None = None,
+) -> list[RunSummary]:
+    """Scan runs directory and return summaries filtered by optional date range.
+
+    Args:
+        runs_dir: Directory containing timestamped run subdirectories.
+        date_from: Optional inclusive start date (YYYY-MM-DD).
+        date_to: Optional inclusive end date (YYYY-MM-DD).
+
+    Returns:
+        List of RunSummary sorted by timestamp ascending.
+    """
+    from_dt = _parse_date_bound(date_from) if date_from else None
+    # Make to_dt inclusive of the full day
+    to_dt = None
+    if date_to:
+        to_dt = _parse_date_bound(date_to).replace(
+            hour=23, minute=59, second=59, microsecond=999999
+        )
+
+    results: list[RunSummary] = []
+
+    if not runs_dir.is_dir():
+        return results
+
+    for entry in sorted(runs_dir.iterdir()):
+        if not entry.is_dir():
+            continue
+
+        meta_path = entry / "meta.yaml"
+        junit_path = entry / "junit.xml"
+        if not meta_path.exists() or not junit_path.exists():
+            continue
+
+        try:
+            meta = yaml.safe_load(meta_path.read_text()) or {}
+        except Exception:
+            continue
+
+        run_ts = _parse_timestamp(meta)
+        if run_ts is None:
+            continue
+
+        # Ensure timezone-aware for comparison
+        if run_ts.tzinfo is None:
+            run_ts = run_ts.replace(tzinfo=timezone.utc)
+
+        if from_dt and run_ts < from_dt:
+            continue
+        if to_dt and run_ts > to_dt:
+            continue
+
+        try:
+            suites = _extract_suites(junit_path)
+        except Exception:
+            continue
+
+        repeat_count = meta.get("repeat", 1)
+        if not isinstance(repeat_count, int):
+            repeat_count = 1
+
+        results.append(
+            RunSummary(
+                run_id=meta.get("run_id", entry.name),
+                timestamp=run_ts.isoformat(),
+                assistants=sorted(set(s.assistant for s in suites)),
+                tasks=sorted(set(s.task for s in suites)),
+                repeat=repeat_count,
+                suites=suites,
+            )
+        )
+
+    results.sort(key=lambda r: r.timestamp)
+    return results

--- a/src/pitlane/dashboard/server.py
+++ b/src/pitlane/dashboard/server.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from pathlib import Path
+from urllib.parse import urlparse, parse_qs
+
+from jinja2 import Environment, FileSystemLoader
+
+from pitlane.dashboard.scanner import scan_runs
+
+_tmpl_dir = Path(__file__).parent.parent / "reporting" / "templates"
+_jinja_env = Environment(loader=FileSystemLoader(str(_tmpl_dir)), autoescape=True)
+
+
+class DashboardHandler(BaseHTTPRequestHandler):
+    """Request handler for the trends dashboard."""
+
+    runs_dir: Path  # set via subclass before starting server
+
+    def do_GET(self) -> None:
+        parsed = urlparse(self.path)
+        path = parsed.path.rstrip("/") or "/"
+
+        if path == "/":
+            self._serve_html()
+        elif path == "/api/runs":
+            self._serve_runs_api(parsed.query)
+        else:
+            self.send_error(404)
+
+    def _serve_html(self) -> None:
+        template = _jinja_env.get_template("trends.html.j2")
+        html = template.render(runs_dir=str(self.runs_dir))
+        body = html.encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _serve_runs_api(self, query_string: str) -> None:
+        params = parse_qs(query_string)
+        date_from = params.get("from", [None])[0]
+        date_to = params.get("to", [None])[0]
+
+        runs = scan_runs(self.runs_dir, date_from=date_from, date_to=date_to)
+
+        all_assistants: set[str] = set()
+        all_tasks: set[str] = set()
+        for r in runs:
+            all_assistants.update(r.assistants)
+            all_tasks.update(r.tasks)
+
+        payload = {
+            "runs": [r.to_dict() for r in runs],
+            "meta": {
+                "total_runs": len(runs),
+                "all_assistants": sorted(all_assistants),
+                "all_tasks": sorted(all_tasks),
+            },
+        }
+
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: object) -> None:
+        # Suppress default stderr logging
+        pass
+
+
+def start_server(runs_dir: Path, port: int = 8095, open_browser: bool = True) -> None:
+    """Start the trends dashboard HTTP server."""
+    handler = type("Handler", (DashboardHandler,), {"runs_dir": runs_dir})
+    server = HTTPServer(("127.0.0.1", port), handler)
+
+    url = f"http://127.0.0.1:{port}"
+    print(f"Trends dashboard: {url}")
+    print(f"Scanning runs in: {runs_dir.resolve()}")
+    print("Press Ctrl+C to stop.")
+
+    if open_browser:
+        import webbrowser
+
+        webbrowser.open(url)
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nStopping dashboard server.")
+    finally:
+        server.server_close()

--- a/src/pitlane/reporting/templates/trends.html.j2
+++ b/src/pitlane/reporting/templates/trends.html.j2
@@ -1,0 +1,748 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pitlane Trends</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js" integrity="sha384-vsrfeLOOY6KuIYKDlmVH5UiBmgIdB1oEf7p01YgWHuqmOHfZr374+odEv96n9tNC" crossorigin="anonymous"></script>  {# pragma: allowlist secret #}
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      font-size: 14px;
+      line-height: 1.5;
+      color: #1f2937;
+      background: #f3f4f6;
+    }
+
+    .header {
+      background: #1a1a2e;
+      color: #e5e7eb;
+      padding: 16px 24px;
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+    .header h1 {
+      font-size: 18px;
+      font-weight: 600;
+      color: #fff;
+      flex: 1;
+    }
+    .header .run-dir {
+      font-size: 12px;
+      color: #9ca3af;
+      font-family: monospace;
+      word-break: break-all;
+    }
+
+    .controls-bar {
+      background: #fff;
+      border-bottom: 1px solid #e5e7eb;
+      padding: 12px 24px;
+      display: flex;
+      gap: 16px;
+      flex-wrap: wrap;
+      align-items: center;
+    }
+    .control-group {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+    .control-group label {
+      font-size: 12px;
+      font-weight: 600;
+      color: #6b7280;
+      text-transform: uppercase;
+      letter-spacing: .04em;
+      white-space: nowrap;
+    }
+    .control-group input[type="date"],
+    .control-group select {
+      font-size: 13px;
+      padding: 5px 8px;
+      border: 1px solid #d1d5db;
+      border-radius: 6px;
+      background: #f9fafb;
+      color: #374151;
+    }
+    .btn {
+      padding: 6px 16px;
+      border: none;
+      border-radius: 6px;
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      background: #3b82f6;
+      color: #fff;
+      transition: background .15s;
+    }
+    .btn:hover { background: #2563eb; }
+    .btn-secondary {
+      background: #e5e7eb;
+      color: #374151;
+    }
+    .btn-secondary:hover { background: #d1d5db; }
+
+    .summary {
+      display: flex;
+      gap: 16px;
+      padding: 24px 24px 8px;
+      flex-wrap: wrap;
+    }
+    .card {
+      background: #fff;
+      border-radius: 8px;
+      box-shadow: 0 1px 3px rgba(0,0,0,.1);
+      padding: 16px 20px;
+      min-width: 110px;
+      text-align: center;
+    }
+    .card .card-label {
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: .05em;
+      color: #6b7280;
+    }
+    .card .card-value {
+      font-size: 28px;
+      font-weight: 700;
+      margin-top: 4px;
+      color: #374151;
+    }
+
+    .charts-section {
+      padding: 16px 24px;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+    .chart-card {
+      background: #fff;
+      border-radius: 8px;
+      box-shadow: 0 1px 3px rgba(0,0,0,.1);
+      overflow: hidden;
+    }
+    .chart-card-header {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 12px 16px;
+      border-bottom: 1px solid #e5e7eb;
+      flex-wrap: wrap;
+    }
+    .chart-card-title {
+      font-size: 14px;
+      font-weight: 700;
+      color: #1f2937;
+    }
+    .chart-controls {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-left: auto;
+      flex-wrap: wrap;
+    }
+    .chart-controls label {
+      font-size: 12px;
+      font-weight: 600;
+      color: #6b7280;
+      text-transform: uppercase;
+      letter-spacing: .04em;
+    }
+    .chart-controls select {
+      font-size: 13px;
+      padding: 4px 8px;
+      border: 1px solid #d1d5db;
+      border-radius: 6px;
+      background: #f9fafb;
+      color: #374151;
+      cursor: pointer;
+    }
+    .chart-container {
+      padding: 16px;
+    }
+    .chart-container canvas {
+      max-height: 400px;
+    }
+
+    .assistant-toggles {
+      padding: 8px 24px 24px;
+    }
+    .toggle-card {
+      background: #fff;
+      border-radius: 8px;
+      box-shadow: 0 1px 3px rgba(0,0,0,.1);
+      padding: 12px 16px;
+    }
+    .toggle-title {
+      font-size: 12px;
+      font-weight: 600;
+      color: #6b7280;
+      text-transform: uppercase;
+      letter-spacing: .04em;
+      margin-bottom: 8px;
+    }
+    .toggle-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+    .toggle-item {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 13px;
+      cursor: pointer;
+      user-select: none;
+    }
+    .toggle-item input[type="checkbox"] {
+      cursor: pointer;
+    }
+    .toggle-swatch {
+      display: inline-block;
+      width: 12px;
+      height: 12px;
+      border-radius: 3px;
+    }
+
+    .loading {
+      text-align: center;
+      padding: 48px;
+      color: #6b7280;
+      font-size: 15px;
+    }
+    .empty-state {
+      text-align: center;
+      padding: 48px;
+      color: #9ca3af;
+    }
+
+    .hidden { display: none !important; }
+  </style>
+</head>
+<body>
+
+<div class="header">
+  <h1>Pitlane Trends</h1>
+  <span class="run-dir">{{ runs_dir }}</span>
+</div>
+
+<div class="controls-bar">
+  <div class="control-group">
+    <label for="date-from">From</label>
+    <input type="date" id="date-from">
+  </div>
+  <div class="control-group">
+    <label for="date-to">To</label>
+    <input type="date" id="date-to">
+  </div>
+  <div class="control-group">
+    <label for="task-filter">Task</label>
+    <select id="task-filter">
+      <option value="__all__">All tasks (avg)</option>
+    </select>
+  </div>
+  <button class="btn" id="btn-load">Load</button>
+  <button class="btn btn-secondary" id="btn-reset">Reset</button>
+</div>
+
+<div id="loading" class="loading">Loading runs...</div>
+<div id="empty" class="empty-state hidden">No runs found for the selected date range.</div>
+
+<div id="main-content" class="hidden">
+
+  <div class="summary" id="summary-cards">
+    <div class="card">
+      <div class="card-label">Runs</div>
+      <div class="card-value" id="card-runs">0</div>
+    </div>
+    <div class="card">
+      <div class="card-label">Assistants</div>
+      <div class="card-value" id="card-assistants">0</div>
+    </div>
+    <div class="card">
+      <div class="card-label">Tasks</div>
+      <div class="card-value" id="card-tasks">0</div>
+    </div>
+    <div class="card">
+      <div class="card-label">Date Range</div>
+      <div class="card-value" id="card-range" style="font-size: 16px;">-</div>
+    </div>
+  </div>
+
+  <div class="charts-section">
+    <!-- Default trend chart -->
+    <div class="chart-card">
+      <div class="chart-card-header">
+        <span class="chart-card-title">Trend</span>
+        <div class="chart-controls">
+          <label for="trend-metric">Y Axis</label>
+          <select id="trend-metric"></select>
+        </div>
+      </div>
+      <div class="chart-container">
+        <canvas id="chart-trend"></canvas>
+      </div>
+    </div>
+
+    <!-- Second trend chart -->
+    <div class="chart-card">
+      <div class="chart-card-header">
+        <span class="chart-card-title">Trend 2</span>
+        <div class="chart-controls">
+          <label for="trend-metric-2">Y Axis</label>
+          <select id="trend-metric-2"></select>
+        </div>
+      </div>
+      <div class="chart-container">
+        <canvas id="chart-trend-2"></canvas>
+      </div>
+    </div>
+  </div>
+
+  <div class="assistant-toggles">
+    <div class="toggle-card">
+      <div class="toggle-title">Assistants</div>
+      <div class="toggle-list" id="assistant-toggles"></div>
+    </div>
+  </div>
+
+</div>
+
+<script>
+/* ── State ─────────────────────────────────────────────────────────────── */
+var runsData = [];
+var metaData = {};
+var assistantColors = {};
+var assistantVisible = {};
+
+/* ── Palette (qualitative, colorblind-friendly) ───────────────────────── */
+var palette = [
+  '#3b82f6', '#ef4444', '#22c55e', '#f59e0b', '#8b5cf6',
+  '#ec4899', '#06b6d4', '#f97316', '#14b8a6', '#6366f1',
+  '#a855f7', '#84cc16', '#e11d48', '#0891b2'
+];
+
+function assignColors(assistants) {
+  assistantColors = {};
+  for (var i = 0; i < assistants.length; i++) {
+    assistantColors[assistants[i]] = palette[i % palette.length];
+  }
+}
+
+/* ── Metric definitions ────────────────────────────────────────────────── */
+var metricLabels = {
+  weighted_score: 'Weighted Score',
+  assertion_pass_rate: 'Assertion Pass Rate (%)',
+  cost_usd: 'Cost (USD)',
+  wall_clock_seconds: 'Time (seconds)',
+  token_usage_input: 'Input Tokens',
+  token_usage_output: 'Output Tokens',
+  token_usage_input_cached: 'Cached Input Tokens',
+  tool_calls_count: 'Tool Calls',
+  files_created: 'Files Created',
+  files_modified: 'Files Modified',
+  timed_out: 'Timed Out'
+};
+
+var defaultTrendMetric = 'weighted_score';
+
+/* ── Data fetching ─────────────────────────────────────────────────────── */
+function fetchRuns(dateFrom, dateTo) {
+  var url = '/api/runs';
+  var params = [];
+  if (dateFrom) params.push('from=' + encodeURIComponent(dateFrom));
+  if (dateTo) params.push('to=' + encodeURIComponent(dateTo));
+  if (params.length) url += '?' + params.join('&');
+
+  return fetch(url).then(function(r) { return r.json(); });
+}
+
+/* ── Compute average of a metric across matching suites for an assistant ── */
+function avgMetric(suites, assistant, metricKey, taskFilter) {
+  var sum = 0, count = 0;
+  for (var i = 0; i < suites.length; i++) {
+    var s = suites[i];
+    if (s.assistant !== assistant) continue;
+    if (taskFilter !== '__all__' && s.task !== taskFilter) continue;
+    var v = s[metricKey];
+    if (v !== null && v !== undefined) { sum += v; count++; }
+  }
+  return count > 0 ? sum / count : null;
+}
+
+/* ── Build series for trend chart with enriched data points ────────────── */
+var defaultSecondary = ['weighted_score', 'cost_usd'];
+var secondaryMetrics = {
+  weighted_score: ['cost_usd', 'wall_clock_seconds'],
+  cost_usd: ['weighted_score', 'wall_clock_seconds'],
+  wall_clock_seconds: ['weighted_score', 'cost_usd']
+};
+
+function buildTrendSeries(metricKey, taskFilter) {
+  var series = {};
+
+  for (var i = 0; i < runsData.length; i++) {
+    var run = runsData[i];
+    // Collect which assistants have data in this run
+    var assistantsInRun = {};
+    for (var j = 0; j < run.suites.length; j++) {
+      var s = run.suites[j];
+      if (taskFilter !== '__all__' && s.task !== taskFilter) continue;
+      var val = s[metricKey];
+      if (val === null || val === undefined) continue;
+      if (!assistantsInRun[s.assistant]) {
+        assistantsInRun[s.assistant] = { sum: 0, count: 0 };
+      }
+      assistantsInRun[s.assistant].sum += val;
+      assistantsInRun[s.assistant].count += 1;
+    }
+
+    var names = Object.keys(assistantsInRun);
+    for (var k = 0; k < names.length; k++) {
+      var name = names[k];
+      var agg = assistantsInRun[name];
+      var avg = agg.sum / agg.count;
+
+      // Gather secondary metrics
+      var secs = secondaryMetrics[metricKey] || defaultSecondary;
+      var secondary = {};
+      for (var m = 0; m < secs.length; m++) {
+        secondary[secs[m]] = avgMetric(run.suites, name, secs[m], taskFilter);
+      }
+
+      if (!series[name]) series[name] = [];
+      series[name].push({
+        x: run.timestamp,
+        y: avg,
+        run_id: run.run_id,
+        repeat: run.repeat || 1,
+        task_count: agg.count,
+        delta: null,
+        secondary: secondary
+      });
+    }
+  }
+
+  // Compute deltas (change from previous point)
+  var assistantNames = Object.keys(series);
+  for (var a = 0; a < assistantNames.length; a++) {
+    var pts = series[assistantNames[a]];
+    for (var p = 1; p < pts.length; p++) {
+      if (pts[p].y !== null && pts[p - 1].y !== null) {
+        pts[p].delta = pts[p].y - pts[p - 1].y;
+      }
+    }
+  }
+
+  return series;
+}
+
+/* ── Smart timestamp formatting based on data span ─────────────────────── */
+function detectTimeSpan() {
+  if (runsData.length < 2) return 'short';
+  var first = new Date(runsData[0].timestamp);
+  var last = new Date(runsData[runsData.length - 1].timestamp);
+  var diffMs = last - first;
+  var diffDays = diffMs / (1000 * 60 * 60 * 24);
+  if (diffDays < 1) return 'hours';    // same day: show HH:MM
+  if (diffDays <= 7) return 'days';     // within a week: show Mon DD HH:MM
+  return 'weeks';                        // wider: show Mon DD
+}
+
+function formatTimestamp(isoStr, span) {
+  try {
+    var d = new Date(isoStr);
+    if (span === 'hours') {
+      return d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+    } else if (span === 'days') {
+      return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) +
+        ' ' + d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+    } else {
+      return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+    }
+  } catch(e) { return isoStr; }
+}
+
+/* ── Shared tooltip format helpers ──────────────────────────────────────── */
+function fmtVal(v, key) {
+  if (v === null || v === undefined) return '-';
+  if (key === 'cost_usd') return '$' + v.toFixed(4);
+  if (key === 'wall_clock_seconds') return v.toFixed(1) + 's';
+  if (typeof v === 'number') return v.toFixed(2);
+  return String(v);
+}
+
+function buildTooltipTitle(items) {
+  if (!items.length) return '';
+  var p = items[0].raw;
+  var lines = [];
+  try { lines.push(new Date(p.x).toLocaleString()); } catch(e) { lines.push(p.x); }
+  if (p.run_id) lines.push('Run: ' + p.run_id);
+  return lines;
+}
+
+function buildTooltipLabel(ctx, metricKey) {
+  var p = ctx.raw;
+  var lines = [];
+  // Primary value
+  lines.push(ctx.dataset.label + ': ' + fmtVal(p.y, metricKey));
+  // Delta from previous
+  if (p.delta !== null && p.delta !== undefined) {
+    var sign = p.delta >= 0 ? '+' : '';
+    lines.push('Change: ' + sign + fmtVal(p.delta, metricKey));
+  }
+  return lines;
+}
+
+function buildTooltipAfterLabel(ctx, metricKey) {
+  var p = ctx.raw;
+  var lines = [];
+  // Repeat count
+  if (p.repeat && p.repeat > 1) lines.push('Repeats: ' + p.repeat);
+  // Task count (only when aggregating)
+  if (p.task_count && p.task_count > 1) lines.push('Tasks: ' + p.task_count + ' (avg)');
+  // Secondary metrics
+  if (p.secondary) {
+    var secKeys = Object.keys(p.secondary);
+    for (var i = 0; i < secKeys.length; i++) {
+      var sk = secKeys[i];
+      var sv = p.secondary[sk];
+      if (sv !== null && sv !== undefined) {
+        lines.push((metricLabels[sk] || sk) + ': ' + fmtVal(sv, sk));
+      }
+    }
+  }
+  return lines;
+}
+
+function trendChartOptions(metricKey) {
+  return {
+    responsive: true,
+    interaction: { mode: 'nearest', intersect: false },
+    plugins: {
+      legend: { display: true, position: 'top' },
+      tooltip: {
+        callbacks: {
+          title: buildTooltipTitle,
+          label: function(ctx) { return buildTooltipLabel(ctx, metricKey); },
+          afterLabel: function(ctx) { return buildTooltipAfterLabel(ctx, metricKey); }
+        }
+      }
+    },
+    scales: {
+      x: {
+        type: 'category',
+        title: { display: true, text: 'Run' },
+        ticks: {
+          callback: function(value) {
+            var label = this.getLabelForValue(value);
+            return formatTimestamp(label, detectTimeSpan());
+          },
+          maxRotation: 45
+        }
+      },
+      y: {
+        title: { display: true, text: metricLabels[metricKey] || metricKey }
+      }
+    }
+  };
+}
+
+/* ── Build datasets from series ────────────────────────────────────────── */
+function buildDatasets(series) {
+  var datasets = [];
+  var assistants = Object.keys(series);
+  for (var i = 0; i < assistants.length; i++) {
+    var name = assistants[i];
+    if (!assistantVisible[name]) continue;
+    datasets.push({
+      label: name,
+      data: series[name],
+      borderColor: assistantColors[name] || palette[i % palette.length],
+      backgroundColor: assistantColors[name] || palette[i % palette.length],
+      fill: false,
+      tension: 0.2,
+      pointRadius: 5,
+      pointHoverRadius: 7
+    });
+  }
+  return datasets;
+}
+
+/* ── Render a trend chart ───────────────────────────────────────────────── */
+var charts = {};
+
+function renderChart(chartKey, metricSelectId, canvasId) {
+  var metricKey = document.getElementById(metricSelectId).value;
+  var taskFilter = document.getElementById('task-filter').value;
+  var series = buildTrendSeries(metricKey, taskFilter);
+
+  if (charts[chartKey]) charts[chartKey].destroy();
+  charts[chartKey] = new Chart(document.getElementById(canvasId), {
+    type: 'line',
+    data: { datasets: buildDatasets(series) },
+    options: trendChartOptions(metricKey)
+  });
+}
+
+function renderAllCharts() {
+  renderChart('trend1', 'trend-metric', 'chart-trend');
+  renderChart('trend2', 'trend-metric-2', 'chart-trend-2');
+}
+
+/* ── Populate dropdowns ────────────────────────────────────────────────── */
+function populateMetricDropdowns() {
+  var keys = Object.keys(metricLabels);
+  var trendSel = document.getElementById('trend-metric');
+  var trendSel2 = document.getElementById('trend-metric-2');
+
+  // Check which metrics have data
+  var available = keys.filter(function(k) {
+    for (var i = 0; i < runsData.length; i++) {
+      for (var j = 0; j < runsData[i].suites.length; j++) {
+        var v = runsData[i].suites[j][k];
+        if (v !== null && v !== undefined) return true;
+      }
+    }
+    return false;
+  });
+
+  [trendSel, trendSel2].forEach(function(sel) {
+    sel.innerHTML = '';
+    available.forEach(function(k) {
+      var opt = document.createElement('option');
+      opt.value = k; opt.textContent = metricLabels[k];
+      sel.appendChild(opt);
+    });
+  });
+
+  trendSel.value = available.indexOf(defaultTrendMetric) >= 0 ? defaultTrendMetric : available[0];
+  // Default second chart to cost_usd (or second available metric)
+  var defaultMetric2 = 'cost_usd';
+  trendSel2.value = available.indexOf(defaultMetric2) >= 0 ? defaultMetric2 : (available[1] || available[0]);
+}
+
+function populateTaskFilter() {
+  var sel = document.getElementById('task-filter');
+  var current = sel.value;
+  sel.innerHTML = '';
+  var allOpt = document.createElement('option');
+  allOpt.value = '__all__'; allOpt.textContent = 'All tasks (avg)';
+  sel.appendChild(allOpt);
+
+  var tasks = metaData.all_tasks || [];
+  tasks.forEach(function(t) {
+    var opt = document.createElement('option');
+    opt.value = t; opt.textContent = t;
+    sel.appendChild(opt);
+  });
+
+  if (current && tasks.indexOf(current) >= 0) sel.value = current;
+}
+
+function populateAssistantToggles() {
+  var container = document.getElementById('assistant-toggles');
+  container.innerHTML = '';
+  var assistants = metaData.all_assistants || [];
+
+  assistants.forEach(function(name) {
+    if (assistantVisible[name] === undefined) assistantVisible[name] = true;
+    var color = assistantColors[name] || '#6b7280';
+    var label = document.createElement('label');
+    label.className = 'toggle-item';
+
+    var cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.checked = assistantVisible[name];
+    cb.addEventListener('change', function() {
+      assistantVisible[name] = cb.checked;
+      renderAllCharts();
+    });
+
+    var swatch = document.createElement('span');
+    swatch.className = 'toggle-swatch';
+    swatch.style.background = color;
+
+    label.appendChild(cb);
+    label.appendChild(swatch);
+    label.appendChild(document.createTextNode(' ' + name));
+    container.appendChild(label);
+  });
+}
+
+/* ── Update UI with loaded data ────────────────────────────────────────── */
+function updateUI(data) {
+  runsData = data.runs;
+  metaData = data.meta;
+
+  var loading = document.getElementById('loading');
+  var empty = document.getElementById('empty');
+  var main = document.getElementById('main-content');
+
+  loading.classList.add('hidden');
+
+  if (runsData.length === 0) {
+    empty.classList.remove('hidden');
+    main.classList.add('hidden');
+    return;
+  }
+
+  empty.classList.add('hidden');
+  main.classList.remove('hidden');
+
+  // Summary cards
+  document.getElementById('card-runs').textContent = metaData.total_runs;
+  document.getElementById('card-assistants').textContent = metaData.all_assistants.length;
+  document.getElementById('card-tasks').textContent = metaData.all_tasks.length;
+
+  if (runsData.length > 0) {
+    var first = runsData[0].timestamp.slice(0, 10);
+    var last = runsData[runsData.length - 1].timestamp.slice(0, 10);
+    document.getElementById('card-range').textContent = first === last ? first : first + ' \u2192 ' + last;
+  }
+
+  assignColors(metaData.all_assistants);
+  populateMetricDropdowns();
+  populateTaskFilter();
+  populateAssistantToggles();
+  renderAllCharts();
+}
+
+/* ── Event handlers ────────────────────────────────────────────────────── */
+document.getElementById('btn-load').addEventListener('click', function() {
+  var dateFrom = document.getElementById('date-from').value || null;
+  var dateTo = document.getElementById('date-to').value || null;
+  document.getElementById('loading').classList.remove('hidden');
+  document.getElementById('main-content').classList.add('hidden');
+  document.getElementById('empty').classList.add('hidden');
+  fetchRuns(dateFrom, dateTo).then(updateUI);
+});
+
+document.getElementById('btn-reset').addEventListener('click', function() {
+  document.getElementById('date-from').value = '';
+  document.getElementById('date-to').value = '';
+  document.getElementById('loading').classList.remove('hidden');
+  document.getElementById('main-content').classList.add('hidden');
+  document.getElementById('empty').classList.add('hidden');
+  fetchRuns(null, null).then(updateUI);
+});
+
+document.getElementById('trend-metric').addEventListener('change', function() {
+  renderChart('trend1', 'trend-metric', 'chart-trend');
+});
+document.getElementById('trend-metric-2').addEventListener('change', function() {
+  renderChart('trend2', 'trend-metric-2', 'chart-trend-2');
+});
+document.getElementById('task-filter').addEventListener('change', renderAllCharts);
+
+/* ── Initial load ──────────────────────────────────────────────────────── */
+fetchRuns(null, null).then(updateUI);
+</script>
+</body>
+</html>

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,61 @@
+"""Shared test helpers for dashboard tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from pitlane.reporting.junit import write_junit
+
+
+def make_run(
+    base_dir: Path,
+    run_id: str,
+    timestamp: str,
+    results: dict | None = None,
+) -> Path:
+    """Create a synthetic run directory with meta.yaml and junit.xml."""
+    run_dir = base_dir / run_id
+    run_dir.mkdir(parents=True)
+
+    meta = {
+        "run_id": run_id,
+        "timestamp": timestamp,
+        "assistants": [],
+        "tasks": [],
+        "repeat": 1,
+    }
+    (run_dir / "meta.yaml").write_text(yaml.dump(meta))
+
+    if results is None:
+        results = {
+            "claude-baseline": {
+                "task-1": {
+                    "metrics": {
+                        "wall_clock_seconds": 10.0,
+                        "exit_code": 0,
+                        "files_created": 2,
+                        "files_modified": 0,
+                        "total_lines_generated": 50,
+                        "token_usage_input": 500,
+                        "token_usage_output": 200,
+                        "token_usage_input_cached": 100,
+                        "cost_usd": 0.03,
+                        "tool_calls_count": 5,
+                        "assertion_pass_count": 2,
+                        "assertion_fail_count": 0,
+                        "assertion_pass_rate": 100.0,
+                        "weighted_score": 85.0,
+                        "timed_out": 0,
+                    },
+                    "assertions": [
+                        {"name": "file_exists: main.tf", "passed": True, "message": ""},
+                    ],
+                    "all_passed": True,
+                }
+            }
+        }
+
+    write_junit(run_dir, results)
+    return run_dir

--- a/tests/test_dashboard_scanner.py
+++ b/tests/test_dashboard_scanner.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import yaml
+
+from tests.helpers import make_run
+from pitlane.reporting.junit import write_junit
+from pitlane.dashboard.scanner import scan_runs
+
+
+def test_scan_runs_empty_dir(tmp_path):
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    assert scan_runs(runs_dir) == []
+
+
+def test_scan_runs_nonexistent_dir(tmp_path):
+    assert scan_runs(tmp_path / "nonexistent") == []
+
+
+def test_scan_runs_finds_valid_run(tmp_path):
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    make_run(runs_dir, "2026-01-15_100000", "2026-01-15T10:00:00+00:00")
+
+    results = scan_runs(runs_dir)
+    assert len(results) == 1
+    assert results[0].run_id == "2026-01-15_100000"
+    assert len(results[0].suites) == 1
+    assert results[0].suites[0].assistant == "claude-baseline"
+    assert results[0].suites[0].task == "task-1"
+
+
+def test_scan_runs_skips_dir_without_meta(tmp_path):
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    # Create a dir with only junit.xml, no meta.yaml
+    bad_run = runs_dir / "bad-run"
+    bad_run.mkdir()
+    write_junit(
+        bad_run,
+        {
+            "a": {
+                "t": {
+                    "metrics": {"weighted_score": 50.0},
+                    "assertions": [],
+                    "all_passed": True,
+                }
+            }
+        },
+    )
+
+    assert scan_runs(runs_dir) == []
+
+
+def test_scan_runs_skips_dir_without_junit(tmp_path):
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    bad_run = runs_dir / "bad-run"
+    bad_run.mkdir()
+    (bad_run / "meta.yaml").write_text(
+        yaml.dump({"timestamp": "2026-01-01T00:00:00+00:00"})
+    )
+
+    assert scan_runs(runs_dir) == []
+
+
+def test_scan_runs_extracts_metrics(tmp_path):
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    make_run(runs_dir, "run1", "2026-01-15T10:00:00+00:00")
+
+    results = scan_runs(runs_dir)
+    suite = results[0].suites[0]
+    assert suite.weighted_score == 85.0
+    assert suite.assertion_pass_rate == 100.0
+    assert suite.cost_usd == 0.03
+    assert suite.token_usage_input == 500.0
+    assert suite.token_usage_output == 200.0
+    assert suite.tool_calls_count == 5.0
+
+
+def test_scan_runs_sorted_by_timestamp(tmp_path):
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    make_run(runs_dir, "run-late", "2026-03-01T12:00:00+00:00")
+    make_run(runs_dir, "run-early", "2026-01-01T12:00:00+00:00")
+    make_run(runs_dir, "run-mid", "2026-02-01T12:00:00+00:00")
+
+    results = scan_runs(runs_dir)
+    assert len(results) == 3
+    assert results[0].run_id == "run-early"
+    assert results[1].run_id == "run-mid"
+    assert results[2].run_id == "run-late"
+
+
+def test_scan_runs_date_filter_from(tmp_path):
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    make_run(runs_dir, "old", "2026-01-01T10:00:00+00:00")
+    make_run(runs_dir, "new", "2026-03-01T10:00:00+00:00")
+
+    results = scan_runs(runs_dir, date_from="2026-02-01")
+    assert len(results) == 1
+    assert results[0].run_id == "new"
+
+
+def test_scan_runs_date_filter_to(tmp_path):
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    make_run(runs_dir, "old", "2026-01-01T10:00:00+00:00")
+    make_run(runs_dir, "new", "2026-03-01T10:00:00+00:00")
+
+    results = scan_runs(runs_dir, date_to="2026-02-01")
+    assert len(results) == 1
+    assert results[0].run_id == "old"
+
+
+def test_scan_runs_date_filter_range(tmp_path):
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    make_run(runs_dir, "jan", "2026-01-15T10:00:00+00:00")
+    make_run(runs_dir, "feb", "2026-02-15T10:00:00+00:00")
+    make_run(runs_dir, "mar", "2026-03-15T10:00:00+00:00")
+
+    results = scan_runs(runs_dir, date_from="2026-02-01", date_to="2026-02-28")
+    assert len(results) == 1
+    assert results[0].run_id == "feb"
+
+
+def test_scan_runs_to_date_inclusive(tmp_path):
+    """The to date should include runs from that entire day."""
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    make_run(runs_dir, "run", "2026-02-15T23:59:00+00:00")
+
+    results = scan_runs(runs_dir, date_to="2026-02-15")
+    assert len(results) == 1
+
+
+def test_scan_runs_multiple_assistants(tmp_path):
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    results_data = {
+        "claude-baseline": {
+            "task-1": {
+                "metrics": {"weighted_score": 80.0, "assertion_pass_rate": 100.0},
+                "assertions": [{"name": "a", "passed": True, "message": ""}],
+                "all_passed": True,
+            }
+        },
+        "claude-with-skill": {
+            "task-1": {
+                "metrics": {"weighted_score": 95.0, "assertion_pass_rate": 100.0},
+                "assertions": [{"name": "a", "passed": True, "message": ""}],
+                "all_passed": True,
+            }
+        },
+    }
+    make_run(runs_dir, "run1", "2026-01-15T10:00:00+00:00", results_data)
+
+    results = scan_runs(runs_dir)
+    assert len(results) == 1
+    assert len(results[0].suites) == 2
+    assert set(results[0].assistants) == {"claude-baseline", "claude-with-skill"}
+
+
+def test_scan_runs_default_repeat(tmp_path):
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    make_run(runs_dir, "run1", "2026-01-15T10:00:00+00:00")
+
+    results = scan_runs(runs_dir)
+    assert results[0].repeat == 1
+
+
+def test_scan_runs_repeat_from_meta(tmp_path):
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    run_dir = make_run(runs_dir, "run1", "2026-01-15T10:00:00+00:00")
+    # Overwrite meta.yaml with repeat=3
+    meta = yaml.safe_load((run_dir / "meta.yaml").read_text())
+    meta["repeat"] = 3
+    (run_dir / "meta.yaml").write_text(yaml.dump(meta))
+
+    results = scan_runs(runs_dir)
+    assert results[0].repeat == 3
+
+
+def test_run_summary_to_dict(tmp_path):
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    make_run(runs_dir, "run1", "2026-01-15T10:00:00+00:00")
+
+    results = scan_runs(runs_dir)
+    d = results[0].to_dict()
+    assert isinstance(d, dict)
+    assert d["run_id"] == "run1"
+    assert d["repeat"] == 1
+    assert isinstance(d["suites"], list)
+    assert isinstance(d["suites"][0], dict)
+    assert "weighted_score" in d["suites"][0]

--- a/tests/test_dashboard_server.py
+++ b/tests/test_dashboard_server.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+import threading
+import urllib.request
+from http.server import HTTPServer
+
+import pytest
+
+from tests.helpers import make_run
+from pitlane.dashboard.server import DashboardHandler
+
+
+_SERVER_TEST_RESULTS = {
+    "claude-baseline": {
+        "task-1": {
+            "metrics": {"weighted_score": 90.0, "assertion_pass_rate": 100.0},
+            "assertions": [{"name": "check", "passed": True, "message": ""}],
+            "all_passed": True,
+        }
+    }
+}
+
+
+@pytest.fixture
+def runs_dir(tmp_path):
+    runs = tmp_path / "runs"
+    runs.mkdir()
+    make_run(runs, "run1", "2026-01-15T10:00:00+00:00", _SERVER_TEST_RESULTS)
+    make_run(runs, "run2", "2026-02-15T10:00:00+00:00", _SERVER_TEST_RESULTS)
+    return runs
+
+
+@pytest.fixture
+def server_url(runs_dir):
+    """Start a test server on a random port and yield its base URL."""
+    handler = type("TestHandler", (DashboardHandler,), {"runs_dir": runs_dir})
+    httpd = HTTPServer(("127.0.0.1", 0), handler)
+    port = httpd.server_address[1]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{port}"
+    httpd.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_root_returns_html(server_url):
+    req = urllib.request.Request(server_url + "/")
+    with urllib.request.urlopen(req) as resp:
+        assert resp.status == 200
+        content_type = resp.headers.get("Content-Type", "")
+        assert "text/html" in content_type
+        body = resp.read().decode()
+        assert "Pitlane Trends" in body
+
+
+def test_api_runs_returns_json(server_url):
+    req = urllib.request.Request(server_url + "/api/runs")
+    with urllib.request.urlopen(req) as resp:
+        assert resp.status == 200
+        content_type = resp.headers.get("Content-Type", "")
+        assert "application/json" in content_type
+        data = json.loads(resp.read())
+        assert "runs" in data
+        assert "meta" in data
+        assert data["meta"]["total_runs"] == 2
+
+
+def test_api_runs_with_date_filter(server_url):
+    req = urllib.request.Request(server_url + "/api/runs?from=2026-02-01")
+    with urllib.request.urlopen(req) as resp:
+        data = json.loads(resp.read())
+        assert data["meta"]["total_runs"] == 1
+        assert data["runs"][0]["run_id"] == "run2"
+
+
+def test_api_runs_structure(server_url):
+    req = urllib.request.Request(server_url + "/api/runs")
+    with urllib.request.urlopen(req) as resp:
+        data = json.loads(resp.read())
+        run = data["runs"][0]
+        assert "run_id" in run
+        assert "timestamp" in run
+        assert "suites" in run
+        suite = run["suites"][0]
+        assert "assistant" in suite
+        assert "task" in suite
+        assert "weighted_score" in suite
+
+
+def test_unknown_path_returns_404(server_url):
+    req = urllib.request.Request(server_url + "/nonexistent")
+    with pytest.raises(urllib.error.HTTPError) as exc_info:
+        urllib.request.urlopen(req)
+    assert exc_info.value.code == 404
+
+
+def test_api_runs_empty_dir(tmp_path):
+    """Server with empty runs dir returns zero runs."""
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    handler = type("TestHandler", (DashboardHandler,), {"runs_dir": empty_dir})
+    httpd = HTTPServer(("127.0.0.1", 0), handler)
+    port = httpd.server_address[1]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        req = urllib.request.Request(f"http://127.0.0.1:{port}/api/runs")
+        with urllib.request.urlopen(req) as resp:
+            data = json.loads(resp.read())
+            assert data["meta"]["total_runs"] == 0
+            assert data["runs"] == []
+    finally:
+        httpd.shutdown()


### PR DESCRIPTION
<img width="2515" height="1314" alt="image" src="https://github.com/user-attachments/assets/109e1544-8ccd-4a46-994a-dba567e73e5c" />

## Summary

- Adds `pitlane trends` CLI command that starts a local HTTP server with an
interactive Chart.js dashboard
- Scanner reads `meta.yaml` and `junit.xml` from each run directory, with optional
date-range filtering
- Dashboard renders two configurable time-series charts per assistant, with metric
selection, task filtering, and assistant toggles
- Rich tooltips show delta from previous run, secondary metrics, and repeat count

## What's included

- `src/pitlane/dashboard/scanner.py` — parses run directories into
`RunSummary`/`SuiteSummary` dataclasses
- `src/pitlane/dashboard/server.py` — lightweight `http.server` with `/` (HTML) and
`/api/runs` (JSON) endpoints
- `src/pitlane/reporting/templates/trends.html.j2` — self-contained SPA with
Chart.js
- `src/pitlane/cli.py` — new `trends` command with `--runs-dir`, `--port`,
`--no-open` options
- 21 tests covering scanner logic, date filtering, server endpoints, and edge cases

## Test plan

- [x] `uv run pytest tests/test_dashboard_scanner.py tests/test_dashboard_server.py
-v` — 21 tests pass
- [x] Manual: `pitlane trends --runs-dir <dir>` opens browser with chart data
- [x] Manual: date filters and task/assistant toggles update charts correctly